### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -43,8 +43,9 @@ jobs:
     - name: Install cargo-tarpaulin
       uses: taiki-e/install-action@cargo-tarpaulin
     - name: Check code coverage with cargo-tarpaulin
-      run: cargo-tarpaulin --workspace --all-features --out xml
+      run: make coverage
     - name: Upload to codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -33,3 +33,18 @@ jobs:
       run: cargo test --release
     - name: Check all examples, binaries, etc
       run: cargo check --all-targets
+  coverage:
+    runs-on: ubuntu-latest
+    name: cargo-tarpaulin
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get latest version of stable Rust
+      run: rustup update stable
+    - name: Install cargo-tarpaulin
+      uses: taiki-e/install-action@cargo-tarpaulin
+    - name: Check code coverage with cargo-tarpaulin
+      run: cargo-tarpaulin --workspace --all-features --out xml
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target
+cobertura.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# These hacks are required for the test binaries depending on the dynamic library libstd-*.so
+# See: https://github.com/rust-lang/cargo/issues/4651
+#
+# We also need to exclude the derive macro from coverage because it will always show as 0% by
+# virtue of executing at compile-time outside the view of Tarpaulin.
+coverage:
+	env LD_LIBRARY_PATH="$(shell rustc --print sysroot)/lib" \
+	cargo-tarpaulin --workspace --all-features --out xml --exclude tree_hash_derive
+
+.PHONY: coverage


### PR DESCRIPTION
Adds code coverage using `cargo-tarpaulin` and uploads the results to codecov.io to generate a coverage report.