### PR TITLE
Update `ethereum_hashing` to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "tree_hash",
     "tree_hash_derive",
 ]
+resolver = "2"

--- a/tree_hash/Cargo.toml
+++ b/tree_hash/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 ethereum-types = "0.14.1"
-ethereum_hashing = "1.0.0-beta.2"
+ethereum_hashing = "0.6.0"
 smallvec = "1.6.1"
 
 [dev-dependencies]
 rand = "0.8.5"
 tree_hash_derive = { path = "../tree_hash_derive", version = "0.5.2" }
-ethereum_ssz = "1.0.0-beta.2"
-ethereum_ssz_derive = "1.0.0-beta.2"
+ethereum_ssz = "0.5"
+ethereum_ssz_derive = "0.5"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]


### PR DESCRIPTION
Updating `ethereum_hashing` for improved compatibility (see https://github.com/sigp/ethereum_hashing/pull/6).