### PR TITLE
Derive the standard Error trait using the thiserror crate

### DIFF
--- a/tree_hash/Cargo.toml
+++ b/tree_hash/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["cryptography::cryptocurrencies"]
 ethereum-types = "0.14.1"
 ethereum_hashing = "0.6.0"
 smallvec = "1.6.1"
+thiserror = "1.0.58"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/tree_hash/src/merkle_hasher.rs
+++ b/tree_hash/src/merkle_hasher.rs
@@ -2,12 +2,14 @@ use crate::{get_zero_hash, Hash256, HASHSIZE};
 use ethereum_hashing::{Context, Sha256Context, HASH_LEN};
 use smallvec::{smallvec, SmallVec};
 use std::mem;
+use thiserror::Error;
 
 type SmallVec8<T> = SmallVec<[T; 8]>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Error, Clone, Debug, PartialEq)]
 pub enum Error {
     /// The maximum number of leaves defined by the initialization `depth` has been exceed.
+    #[error("The maximum number of leaves {max_leaves} has beed exceed.")]
     MaximumLeavesExceeded { max_leaves: usize },
 }
 


### PR DESCRIPTION
Enhance the `Error` type by implementing the `std::error::Error` trait with the aid of the `thiserror` crate.

This enhancement will streamline the process of integrating this error type with various other error management strategies.