### PR TITLE
Update derive deps & remove cached_tree_hash

### DIFF
--- a/tree_hash_derive/Cargo.toml
+++ b/tree_hash_derive/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["cryptography::cryptocurrencies"]
 proc-macro = true
 
 [dependencies]
-syn = "1.0.42"
-quote = "1.0.7"
-darling = "0.13.0"
+syn = "2.0.69"
+proc-macro2 = "1.0.23"
+quote = "1.0.18"
+darling = "0.20.9"


### PR DESCRIPTION
Update dependencies including `darling` and `syn`.

Rather than updating the `cached_tree_hash` parsing code I opted to delete it, as it is now no longer necessary in Lighthouse and incredibly unlikely to be used elsewhere.

See also:

- https://github.com/sigp/lighthouse/pull/6060

This is a _breaking change_.