### PR TITLE
Add `TreeHashMut`

### DIFF
--- a/tree_hash/src/lib.rs
+++ b/tree_hash/src/lib.rs
@@ -119,6 +119,16 @@ pub trait TreeHash {
     fn tree_hash_root(&self) -> Hash256;
 }
 
+pub trait TreeHashMut {
+    fn tree_hash_type_mut() -> TreeHashType;
+
+    fn tree_hash_packed_encoding_mut(&self) -> PackedEncoding;
+
+    fn tree_hash_packing_factor_mut() -> usize;
+
+    fn tree_hash_root_mut(&mut self) -> Hash256;
+}
+
 /// Punch through references.
 impl<'a, T> TreeHash for &'a T
 where
@@ -138,6 +148,27 @@ where
 
     fn tree_hash_root(&self) -> Hash256 {
         T::tree_hash_root(*self)
+    }
+}
+
+impl<T> TreeHashMut for T
+where
+    T: TreeHash,
+{
+    fn tree_hash_type_mut() -> TreeHashType {
+        <T as TreeHash>::tree_hash_type()
+    }
+
+    fn tree_hash_packed_encoding_mut(&self) -> PackedEncoding {
+        <T as TreeHash>::tree_hash_packed_encoding(self)
+    }
+
+    fn tree_hash_packing_factor_mut() -> usize {
+        <T as TreeHash>::tree_hash_packing_factor()
+    }
+
+    fn tree_hash_root_mut(&mut self) -> Hash256 {
+        <T as TreeHash>::tree_hash_root(self)
     }
 }
 


### PR DESCRIPTION
Define a new `TreeHashMut` trait which takes `&mut self`

This might be a cleaner alternative to:

- https://github.com/sigp/tree_hash/pull/23

Although we got bogged down in the Milhouse changes, especially around supporting nested lists: `List<List<u64, N>, M>` is troublesome because the `T` in `List<T>` should probably implement `TreeHashMut`, but we don't have mutable access to the elements of an immutable list.

_Another_ alternative might be to embrace interior mutability in Milhouse so that TreeHash can be implemented without mutation altogether.