### PR TITLE
Release v0.9.0

### DIFF
--- a/tree_hash/Cargo.toml
+++ b/tree_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_hash"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Efficient Merkle-hashing as used in Ethereum consensus"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ typenum = "1.12.0"
 
 [dev-dependencies]
 rand = "0.8.5"
-tree_hash_derive = { path = "../tree_hash_derive", version = "0.8.0" }
+tree_hash_derive = { path = "../tree_hash_derive", version = "0.9.0" }
 ethereum_ssz_derive = "0.8.0"
 
 [features]

--- a/tree_hash_derive/Cargo.toml
+++ b/tree_hash_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_hash_derive"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Procedural derive macros to accompany the tree_hash crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New release for the relocation of bitfield types into `ethereum_ssz`.