### PR TITLE
Generic `FixedBytes` implementation and bug fixes

### DIFF
--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -57,35 +57,7 @@ impl TreeHash for bool {
     }
 }
 
-/// Only valid for byte types less than 32 bytes.
-macro_rules! impl_for_lt_32byte_u8_array {
-    ($len: expr) => {
-        impl TreeHash for [u8; $len] {
-            fn tree_hash_type() -> TreeHashType {
-                TreeHashType::Vector
-            }
-
-            fn tree_hash_packed_encoding(&self) -> PackedEncoding {
-                unreachable!("bytesN should never be packed.")
-            }
-
-            fn tree_hash_packing_factor() -> usize {
-                unreachable!("bytesN should never be packed.")
-            }
-
-            fn tree_hash_root(&self) -> Hash256 {
-                let mut result = [0; 32];
-                result[0..$len].copy_from_slice(&self[..]);
-                Hash256::from_slice(&result)
-            }
-        }
-    };
-}
-
-impl_for_lt_32byte_u8_array!(4);
-impl_for_lt_32byte_u8_array!(32);
-
-impl TreeHash for [u8; 48] {
+impl<const N: usize> TreeHash for [u8; N] {
     fn tree_hash_type() -> TreeHashType {
         TreeHashType::Vector
     }
@@ -100,7 +72,7 @@ impl TreeHash for [u8; 48] {
 
     fn tree_hash_root(&self) -> Hash256 {
         let values_per_chunk = BYTES_PER_CHUNK;
-        let minimum_chunk_count = (48 + values_per_chunk - 1) / values_per_chunk;
+        let minimum_chunk_count = (N + values_per_chunk - 1) / values_per_chunk;
         merkle_root(self, minimum_chunk_count)
     }
 }
@@ -147,11 +119,11 @@ impl TreeHash for Address {
     }
 
     fn tree_hash_packed_encoding(&self) -> PackedEncoding {
-        unreachable!("Vector should not be packed")
+        unreachable!("Vector should never be packed.")
     }
 
     fn tree_hash_packing_factor() -> usize {
-        unreachable!("Vector should not be packed")
+        unreachable!("Vector should never be packed.")
     }
 
     fn tree_hash_root(&self) -> Hash256 {
@@ -168,16 +140,15 @@ impl<const N: usize> TreeHash for FixedBytes<N> {
     }
 
     fn tree_hash_packed_encoding(&self) -> PackedEncoding {
-        unreachable!("Vector should not be packed")
+        unreachable!("Vector should never be packed.")
     }
 
     fn tree_hash_packing_factor() -> usize {
-        unreachable!("Vector should not be packed")
+        unreachable!("Vector should never be packed.")
     }
 
     fn tree_hash_root(&self) -> Hash256 {
-        let minimum_chunk_count: usize = (N + BYTES_PER_CHUNK - 1) / BYTES_PER_CHUNK;
-        merkle_root(&self.0, minimum_chunk_count)
+        self.0.tree_hash_root()
     }
 }
 

--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -302,6 +302,65 @@ mod test {
         );
     }
 
+    #[test]
+    fn fixed_bytes_7() {
+        let data = [
+            [0, 1, 2, 3, 4, 5, 6],
+            [6, 5, 4, 3, 2, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        ];
+        for bytes in data {
+            assert_eq!(bytes.tree_hash_root(), Hash256::right_padding_from(&bytes));
+        }
+    }
+
+    #[test]
+    fn address() {
+        let data = [
+            Address::ZERO,
+            Address::repeat_byte(0xff),
+            Address::right_padding_from(&[0, 1, 2, 3, 4, 5]),
+            Address::left_padding_from(&[10, 9, 8, 7, 6]),
+        ];
+        for address in data {
+            assert_eq!(
+                address.tree_hash_root(),
+                Hash256::right_padding_from(address.as_slice())
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_bytes_32() {
+        let data = [
+            Hash256::ZERO,
+            Hash256::repeat_byte(0xff),
+            Hash256::right_padding_from(&[0, 1, 2, 3, 4, 5]),
+            Hash256::left_padding_from(&[10, 9, 8, 7, 6]),
+        ];
+        for bytes in data {
+            assert_eq!(bytes.tree_hash_root(), bytes);
+        }
+    }
+
+    #[test]
+    fn fixed_bytes_48() {
+        let data = [
+            (
+                FixedBytes::<48>::ZERO,
+                "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
+            ),
+            (
+                FixedBytes::<48>::repeat_byte(0xff),
+                "0x1e3915ef9ca4ed8619d472b72fb1833448756054b4de9acb439da54dff7166aa",
+            ),
+        ];
+        for (bytes, expected) in data {
+            assert_eq!(bytes.tree_hash_root(), Hash256::from_str(expected).unwrap());
+        }
+    }
+
     // Only basic types should be packed.
     #[test]
     #[should_panic]

--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -147,13 +147,11 @@ impl TreeHash for Address {
     }
 
     fn tree_hash_packed_encoding(&self) -> PackedEncoding {
-        let mut result = [0; 32];
-        result[0..20].copy_from_slice(self.as_slice());
-        PackedEncoding::from_slice(&result)
+        unreachable!("Vector should not be packed")
     }
 
     fn tree_hash_packing_factor() -> usize {
-        1
+        unreachable!("Vector should not be packed")
     }
 
     fn tree_hash_root(&self) -> Hash256 {
@@ -169,11 +167,11 @@ impl TreeHash for B256 {
     }
 
     fn tree_hash_packed_encoding(&self) -> PackedEncoding {
-        PackedEncoding::from_slice(self.as_slice())
+        unreachable!("Vector should not be packed")
     }
 
     fn tree_hash_packing_factor() -> usize {
-        1
+        unreachable!("Vector should not be packed")
     }
 
     fn tree_hash_root(&self) -> Hash256 {

--- a/tree_hash/tests/tests.rs
+++ b/tree_hash/tests/tests.rs
@@ -145,10 +145,6 @@ fn packed_encoding_example() {
         (U128::from(val).tree_hash_packed_encoding(), 0),
         (U128::from(0).tree_hash_packed_encoding(), 16),
         (
-            Hash256::from_slice(U256::from(val).as_le_slice()).tree_hash_packed_encoding(),
-            0,
-        ),
-        (
             Hash256::from_slice(U256::from(val).as_le_slice())
                 .tree_hash_root()
                 .0
@@ -161,10 +157,6 @@ fn packed_encoding_example() {
                 .tree_hash_root()
                 .0
                 .into(),
-            0,
-        ),
-        (
-            Address::from(U160::from(val).to_le_bytes::<20>()).tree_hash_packed_encoding(),
             0,
         ),
     ];


### PR DESCRIPTION
This PR removes the implementations of `tree_hash_packed_encoding` and `tree_hash_packing_factor` for the vector types `Hash256` and `Address`. It then generalises the `TreeHash` implementation to cover all lengths of `FixedBytes`.

Removing packing brings the implementations in line with [the spec](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization), and other implementations of `TreeHash` for types with `tree_hash_type == Vector`.

Downstream users of the `TreeHash` trait should take care not to call the `*packed` methods on types other than "basic" types, as can be seen in `ssz_types`:

https://github.com/sigp/ssz_types/blob/b7f47d95d5cd926a2c299260838f2652a1f962c4/src/tree_hash.rs#L11-L41

And in `milhouse`:

https://github.com/sigp/milhouse/blob/00220dab8b92ed6bbbac48e4543a04923ce1f3eb/src/utils.rs#L67-L72

Arguably the trait is ill-designed in that it has these methods that are guaranteed to panic. I think we should overhaul this in future for a type-safe design, if that can be achieved with minimal performance penalty.