### PR TITLE
Release v0.9.1

### DIFF
--- a/tree_hash/Cargo.toml
+++ b/tree_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_hash"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Efficient Merkle-hashing as used in Ethereum consensus"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ typenum = "1.12.0"
 
 [dev-dependencies]
 rand = "0.8.5"
-tree_hash_derive = { path = "../tree_hash_derive", version = "0.9.0" }
+tree_hash_derive = { path = "../tree_hash_derive", version = "0.9.1" }
 ethereum_ssz_derive = "0.8.0"
 
 [features]

--- a/tree_hash_derive/Cargo.toml
+++ b/tree_hash_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_hash_derive"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Procedural derive macros to accompany the tree_hash crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New release for generalised `FixedBytes`/`[u8; N]` implementations.

This is backwards-compatible, so just a minor/patch bump 0.9.0 -> 0.9.1