### PR TITLE
chore(deps): bump alloy-primitives to 1.0 + ssz

### DIFF
--- a/tree_hash/Cargo.toml
+++ b/tree_hash/Cargo.toml
@@ -11,16 +11,16 @@ keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-alloy-primitives = "0.8.0"
+alloy-primitives = "1.0.0"
 ethereum_hashing = "0.7.0"
-ethereum_ssz = "0.8.0"
+ethereum_ssz = "0.9.0"
 smallvec = "1.6.1"
 typenum = "1.12.0"
 
 [dev-dependencies]
 rand = "0.8.5"
 tree_hash_derive = { path = "../tree_hash_derive", version = "0.9.1" }
-ethereum_ssz_derive = "0.8.0"
+ethereum_ssz_derive = "0.9.0"
 
 [features]
 arbitrary = ["alloy-primitives/arbitrary"]

--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -173,7 +173,7 @@ impl<T: TreeHash> TreeHash for Arc<T> {
 /// A helper function providing common functionality for finding the Merkle root of some bytes that
 /// represent a bitfield.
 pub fn bitfield_bytes_tree_hash_root<N: Unsigned>(bytes: &[u8]) -> Hash256 {
-    let byte_size = (N::to_usize() + 7) / 8;
+    let byte_size = N::to_usize().div_ceil(8);
     let leaf_count = byte_size.div_ceil(BYTES_PER_CHUNK);
 
     let mut hasher = MerkleHasher::with_leaves(leaf_count);

--- a/tree_hash/src/merkle_hasher.rs
+++ b/tree_hash/src/merkle_hasher.rs
@@ -370,7 +370,7 @@ mod test {
     fn context_size() {
         assert_eq!(
             mem::size_of::<HalfNode>(),
-            224,
+            232,
             "Halfnode size should be as expected"
         );
     }


### PR DESCRIPTION
Bump alloy-primitives to 1.0 and ethereum_ssz to 0.9.0

@michaelsproul, sorry for not informing you earlier 🙏🏻, but we missed this and need it for the alloy 1.0 bump just like https://github.com/sigp/ethereum_ssz/pull/47

