### PR TITLE
Type-level struct field access and gindex calc

### DIFF
--- a/tree_hash/Cargo.toml
+++ b/tree_hash/Cargo.toml
@@ -21,6 +21,7 @@ typenum = "1.12.0"
 rand = "0.8.5"
 tree_hash_derive = { path = "../tree_hash_derive", version = "0.10.0" }
 ethereum_ssz_derive = "0.9.0"
+ssz_types = "0.11.0"
 
 [features]
 arbitrary = ["alloy-primitives/arbitrary"]

--- a/tree_hash/src/lib.rs
+++ b/tree_hash/src/lib.rs
@@ -2,6 +2,7 @@ pub mod impls;
 mod merkle_hasher;
 mod merkleize_padded;
 mod merkleize_standard;
+pub mod prototype;
 
 pub use merkle_hasher::{Error, MerkleHasher};
 pub use merkleize_padded::merkleize_padded;

--- a/tree_hash/src/prototype.rs
+++ b/tree_hash/src/prototype.rs
@@ -1,18 +1,21 @@
-/*
-type Hash256 = [u8; 32];
-
-enum Error {
-    Oops
-}
-
-trait TreeHash {
-    fn get_field(&self, index: usize) -> Result<&dyn TreeHash, Error>;
-
-    fn merkle_proof(&self, generalized_index: usize) -> Result<Vec<Hash256>, Error>;
-}
-*/
-use crate::{TreeHash, TreeHashType, BYTES_PER_CHUNK};
+use crate::{Hash256, TreeHash, TreeHashType, BYTES_PER_CHUNK};
 use std::marker::PhantomData;
+
+pub enum Error {
+    Oops,
+}
+
+pub trait MerkleProof: TreeHash {
+    fn compute_proof<F>(&self) -> Result<Vec<Hash256>, Error>
+    where
+        Self: Resolve<F>,
+    {
+        let gindex = <Self as Resolve<F>>::gindex(1);
+        self.compute_proof_for_gindex(gindex)
+    }
+
+    fn compute_proof_for_gindex(&self, gindex: usize) -> Result<Vec<Hash256>, Error>;
+}
 
 // A path is a sequence of field accesses like `self.foo.bar`.
 //
@@ -51,6 +54,7 @@ where
     }
 }
 
+// FIXME: we don't currently enforce I < N at compile-time
 pub struct VecIndex<const I: usize, const N: usize>;
 
 impl<const I: usize, const N: usize> Field for VecIndex<I, N> {

--- a/tree_hash/src/prototype.rs
+++ b/tree_hash/src/prototype.rs
@@ -11,23 +11,24 @@ trait TreeHash {
     fn merkle_proof(&self, generalized_index: usize) -> Result<Vec<Hash256>, Error>;
 }
 */
+use crate::{TreeHash, TreeHashType, BYTES_PER_CHUNK};
 use std::marker::PhantomData;
 
 // A path is a sequence of field accesses like `self.foo.bar`.
 //
 // We can resolve these at compile time, because we're sickos.
-struct Path<First, Rest>(PhantomData<(First, Rest)>);
+pub struct Path<First, Rest>(PhantomData<(First, Rest)>);
 
 // The field trait is implemented for all struct fields.
 //
 // It provides conversion from a named field type to a numeric field index.
-trait Field {
+pub trait Field {
     const NUM_FIELDS: usize;
     const INDEX: usize;
 }
 
 // If T implements Resolve<Field> it means T has a field named Field of type Output.
-trait Resolve<Field> {
+pub trait Resolve<Field> {
     type Output;
 
     fn gindex(parent_index: usize) -> usize;
@@ -50,136 +51,28 @@ where
     }
 }
 
-// Some example structs.
-struct Nested3 {
-    x3: Nested2,
-    y3: Nested1,
+pub struct VecIndex<const I: usize, const N: usize>;
+
+impl<const I: usize, const N: usize> Field for VecIndex<I, N> {
+    const NUM_FIELDS: usize = N;
+    const INDEX: usize = I;
 }
 
-struct Nested2 {
-    x2: Nested1,
-    y2: Nested1,
-}
-
-struct Nested1 {
-    x1: u64,
-    y1: Vec<u64>,
-}
-
-// Fields of Nested3 (these would be generated).
-struct FieldX3;
-struct FieldY3;
-
-impl Field for FieldX3 {
-    const NUM_FIELDS: usize = 2;
-    const INDEX: usize = 0;
-}
-
-impl Field for FieldY3 {
-    const NUM_FIELDS: usize = 2;
-    const INDEX: usize = 1;
-}
-
-// Fields of Nested2 (generated).
-struct FieldX2;
-struct FieldY2;
-
-impl Field for FieldX2 {
-    const NUM_FIELDS: usize = 2;
-    const INDEX: usize = 0;
-}
-
-impl Field for FieldY2 {
-    const NUM_FIELDS: usize = 2;
-    const INDEX: usize = 1;
-}
-
-// Fields of Nested1 (generated).
-struct FieldX1;
-struct FieldY1;
-
-impl Field for FieldX1 {
-    const NUM_FIELDS: usize = 2;
-    const INDEX: usize = 0;
-}
-
-impl Field for FieldY1 {
-    const NUM_FIELDS: usize = 2;
-    const INDEX: usize = 1;
-}
-
-// Implementations of Resolve (generated).
-impl Resolve<FieldX3> for Nested3 {
-    type Output = Nested2;
-
-    fn gindex(parent_index: usize) -> usize {
-        parent_index * <FieldX3 as Field>::NUM_FIELDS.next_power_of_two()
-            + <FieldX3 as Field>::INDEX
+pub fn item_length<T: TreeHash>() -> usize {
+    if T::tree_hash_type() == TreeHashType::Basic {
+        BYTES_PER_CHUNK / T::tree_hash_packing_factor()
+    } else {
+        BYTES_PER_CHUNK
     }
 }
 
-impl Resolve<FieldY3> for Nested3 {
-    type Output = Nested1;
-
-    fn gindex(parent_index: usize) -> usize {
-        parent_index * <FieldY3 as Field>::NUM_FIELDS.next_power_of_two()
-            + <FieldY3 as Field>::INDEX
-    }
+pub fn vector_chunk_count<T: TreeHash>(length: usize) -> usize {
+    (length * item_length::<T>()).div_ceil(BYTES_PER_CHUNK)
 }
 
-impl Resolve<FieldX2> for Nested2 {
-    type Output = Nested1;
-
-    fn gindex(parent_index: usize) -> usize {
-        parent_index * <FieldX2 as Field>::NUM_FIELDS.next_power_of_two()
-            + <FieldX2 as Field>::INDEX
-    }
-}
-
-impl Resolve<FieldY2> for Nested2 {
-    type Output = Nested1;
-
-    fn gindex(parent_index: usize) -> usize {
-        parent_index * <FieldY2 as Field>::NUM_FIELDS.next_power_of_two()
-            + <FieldY2 as Field>::INDEX
-    }
-}
-
-impl Resolve<FieldX1> for Nested1 {
-    type Output = u64;
-
-    fn gindex(parent_index: usize) -> usize {
-        parent_index * <FieldX1 as Field>::NUM_FIELDS.next_power_of_two()
-            + <FieldX1 as Field>::INDEX
-    }
-}
-
-impl Resolve<FieldY1> for Nested1 {
-    type Output = Vec<u64>;
-
-    fn gindex(parent_index: usize) -> usize {
-        parent_index * <FieldY1 as Field>::NUM_FIELDS.next_power_of_two()
-            + <FieldY1 as Field>::INDEX
-    }
-}
-
-// x3.x2.x1
-type FieldX3X2X1 = Path<FieldX3, Path<FieldX2, FieldX1>>;
-
-// x3.x2.x1
-type FieldX3X2Y1 = Path<FieldX3, Path<FieldX2, FieldY1>>;
-
-// This evaluates to u64 at compile-time.
-type TypeOfFieldX3X2X1 = <Nested3 as Resolve<FieldX3X2X1>>::Output;
-
-#[test]
-fn gindex_basics() {
-    // This works but just shows compile-time field resolution.
-    let x: TypeOfFieldX3X2X1 = 0u64;
-
-    // Gindex computation.
-    assert_eq!(<Nested3 as Resolve<FieldX3X2X1>>::gindex(1), 8);
-    assert_eq!(<Nested3 as Resolve<FieldX3X2Y1>>::gindex(1), 9);
+pub fn get_vector_item_position<T: TreeHash>(index: usize) -> usize {
+    let start = index * item_length::<T>();
+    start / BYTES_PER_CHUNK
 }
 
 /*

--- a/tree_hash/src/prototype.rs
+++ b/tree_hash/src/prototype.rs
@@ -1,0 +1,193 @@
+/*
+type Hash256 = [u8; 32];
+
+enum Error {
+    Oops
+}
+
+trait TreeHash {
+    fn get_field(&self, index: usize) -> Result<&dyn TreeHash, Error>;
+
+    fn merkle_proof(&self, generalized_index: usize) -> Result<Vec<Hash256>, Error>;
+}
+*/
+use std::marker::PhantomData;
+
+// A path is a sequence of field accesses like `self.foo.bar`.
+//
+// We can resolve these at compile time, because we're sickos.
+struct Path<First, Rest>(PhantomData<(First, Rest)>);
+
+// The field trait is implemented for all struct fields.
+//
+// It provides conversion from a named field type to a numeric field index.
+trait Field {
+    const NUM_FIELDS: usize;
+    const INDEX: usize;
+}
+
+// If T implements Resolve<Field> it means T has a field named Field of type Output.
+trait Resolve<Field> {
+    type Output;
+
+    fn gindex(parent_index: usize) -> usize;
+}
+
+// This impl defines how paths are resolved and converted to gindices.
+impl<T, First, Rest> Resolve<Path<First, Rest>> for T
+where
+    Self: Resolve<First>,
+    First: Field,
+    <Self as Resolve<First>>::Output: Resolve<Rest>,
+{
+    type Output = <<Self as Resolve<First>>::Output as Resolve<Rest>>::Output;
+
+    fn gindex(parent_index: usize) -> usize {
+        // From `get_generalized_index`:
+        // https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#ssz-object-to-index
+        let new_parent_index = <Self as Resolve<First>>::gindex(parent_index);
+        <Self as Resolve<First>>::Output::gindex(new_parent_index)
+    }
+}
+
+// Some example structs.
+struct Nested3 {
+    x3: Nested2,
+    y3: Nested1,
+}
+
+struct Nested2 {
+    x2: Nested1,
+    y2: Nested1,
+}
+
+struct Nested1 {
+    x1: u64,
+    y1: Vec<u64>,
+}
+
+// Fields of Nested3 (these would be generated).
+struct FieldX3;
+struct FieldY3;
+
+impl Field for FieldX3 {
+    const NUM_FIELDS: usize = 2;
+    const INDEX: usize = 0;
+}
+
+impl Field for FieldY3 {
+    const NUM_FIELDS: usize = 2;
+    const INDEX: usize = 1;
+}
+
+// Fields of Nested2 (generated).
+struct FieldX2;
+struct FieldY2;
+
+impl Field for FieldX2 {
+    const NUM_FIELDS: usize = 2;
+    const INDEX: usize = 0;
+}
+
+impl Field for FieldY2 {
+    const NUM_FIELDS: usize = 2;
+    const INDEX: usize = 1;
+}
+
+// Fields of Nested1 (generated).
+struct FieldX1;
+struct FieldY1;
+
+impl Field for FieldX1 {
+    const NUM_FIELDS: usize = 2;
+    const INDEX: usize = 0;
+}
+
+impl Field for FieldY1 {
+    const NUM_FIELDS: usize = 2;
+    const INDEX: usize = 1;
+}
+
+// Implementations of Resolve (generated).
+impl Resolve<FieldX3> for Nested3 {
+    type Output = Nested2;
+
+    fn gindex(parent_index: usize) -> usize {
+        parent_index * <FieldX3 as Field>::NUM_FIELDS.next_power_of_two()
+            + <FieldX3 as Field>::INDEX
+    }
+}
+
+impl Resolve<FieldY3> for Nested3 {
+    type Output = Nested1;
+
+    fn gindex(parent_index: usize) -> usize {
+        parent_index * <FieldY3 as Field>::NUM_FIELDS.next_power_of_two()
+            + <FieldY3 as Field>::INDEX
+    }
+}
+
+impl Resolve<FieldX2> for Nested2 {
+    type Output = Nested1;
+
+    fn gindex(parent_index: usize) -> usize {
+        parent_index * <FieldX2 as Field>::NUM_FIELDS.next_power_of_two()
+            + <FieldX2 as Field>::INDEX
+    }
+}
+
+impl Resolve<FieldY2> for Nested2 {
+    type Output = Nested1;
+
+    fn gindex(parent_index: usize) -> usize {
+        parent_index * <FieldY2 as Field>::NUM_FIELDS.next_power_of_two()
+            + <FieldY2 as Field>::INDEX
+    }
+}
+
+impl Resolve<FieldX1> for Nested1 {
+    type Output = u64;
+
+    fn gindex(parent_index: usize) -> usize {
+        parent_index * <FieldX1 as Field>::NUM_FIELDS.next_power_of_two()
+            + <FieldX1 as Field>::INDEX
+    }
+}
+
+impl Resolve<FieldY1> for Nested1 {
+    type Output = Vec<u64>;
+
+    fn gindex(parent_index: usize) -> usize {
+        parent_index * <FieldY1 as Field>::NUM_FIELDS.next_power_of_two()
+            + <FieldY1 as Field>::INDEX
+    }
+}
+
+// x3.x2.x1
+type FieldX3X2X1 = Path<FieldX3, Path<FieldX2, FieldX1>>;
+
+// x3.x2.x1
+type FieldX3X2Y1 = Path<FieldX3, Path<FieldX2, FieldY1>>;
+
+// This evaluates to u64 at compile-time.
+type TypeOfFieldX3X2X1 = <Nested3 as Resolve<FieldX3X2X1>>::Output;
+
+#[test]
+fn gindex_basics() {
+    // This works but just shows compile-time field resolution.
+    let x: TypeOfFieldX3X2X1 = 0u64;
+
+    // Gindex computation.
+    assert_eq!(<Nested3 as Resolve<FieldX3X2X1>>::gindex(1), 8);
+    assert_eq!(<Nested3 as Resolve<FieldX3X2Y1>>::gindex(1), 9);
+}
+
+/*
+impl TreeHash for u64 {
+    fn get_field(&self, _: usize) -> Result<&dyn TreeHash, Error> {
+        Err(Error::Oops)
+    }
+
+    fn merkle_proof(&self)
+}
+*/


### PR DESCRIPTION
Some gnarly type hacking towards merkle-proof support with generalised indices.

Working:

- Type-safe access of container fields (see `Resolve`)
- Conversion from type-safe field types to field positions (indices) and gindices
- Field resolution for vec/list-like types. See: https://github.com/sigp/ssz_types/pull/49.

TODO:


- Can we convert a gindex back into a type? (probably not lol).
- Code for producing merkle proofs using gindices.
- Derive macro for all of the above

Something we probably need for structs is caching, where we add an extra field (maybe using the derive) to contain the tree hash cache:

```rust
struct BeaconState {
   slot: Slot,
   validators: List<Validator, ...>,
   ...
   hash_cache: HashCache</* Insert dank type magic to allow typesafe access? */>,
}
```