### PR TITLE
Bump `ethereum_hashing` and `ethereum_ssz` deps

### DIFF
--- a/tree_hash/Cargo.toml
+++ b/tree_hash/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 alloy-primitives = "1.0.0"
-ethereum_hashing = "0.7.0"
-ethereum_ssz = "0.9.0"
+ethereum_hashing = { version = "0.8.0", default-features = false, features = ["zero_hash_cache"]  }
+ethereum_ssz = "0.9.1"
 smallvec = "1.6.1"
 typenum = "1.12.0"
 
@@ -23,4 +23,6 @@ tree_hash_derive = { path = "../tree_hash_derive", version = "0.10.0" }
 ethereum_ssz_derive = "0.9.0"
 
 [features]
+default = ["ring"]
 arbitrary = ["alloy-primitives/arbitrary"]
+ring = ["ethereum_hashing/ring"]


### PR DESCRIPTION
Bump `ethereum_hashing` to `0.8.0` which makes the `ring` dependency optional.

Also bumps the `ethereum_ssz` dependency to the latest version.