### PR TITLE
ProgressiveMerkleHasher and progressive container support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ repository = "https://github.com/sigp/tree_hash"
 keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
 
+# TODO: Remove once ethereum_ssz is published.
 [patch.crates-io]
-ethereum_ssz = { path = "../ethereum_ssz/ssz" }
+ethereum_ssz = { git = "https://github.com/sigp/ethereum_ssz", branch = "progressive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ readme = "README.md"
 repository = "https://github.com/sigp/tree_hash"
 keywords = ["ethereum"]
 categories = ["cryptography::cryptocurrencies"]
+
+[patch.crates-io]
+ethereum_ssz = { path = "../ethereum_ssz/ssz" }

--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -227,9 +227,10 @@ impl TreeHash for Bitfield<Progressive> {
             .write(self.as_slice())
             .expect("ProgessiveBitList should not exceed tree hash leaf limit");
 
-        hasher
+        let bitfield_root = hasher
             .finish()
-            .expect("ProgressiveBitList tree hash buffer should not exceed leaf limit")
+            .expect("ProgressiveBitList tree hash buffer should not exceed leaf limit");
+        mix_in_length(&bitfield_root, self.len())
     }
 }
 

--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -222,8 +222,12 @@ impl TreeHash for Bitfield<Progressive> {
     }
 
     fn tree_hash_root(&self) -> Hash256 {
-        // FIXME(sproul): unclear if this is intended or a bug in the spec tests
-        // See: https://github.com/ethereum/consensus-specs/issues/4795
+        // XXX: This is a workaround for the fact that the internal representation of bitfields is
+        // misaligned with the spec.
+        //
+        // See:
+        //
+        // - https://github.com/sigp/ethereum_ssz/pull/68
         if self.is_empty() {
             return mix_in_length(&Hash256::ZERO, 0);
         }

--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -222,6 +222,12 @@ impl TreeHash for Bitfield<Progressive> {
     }
 
     fn tree_hash_root(&self) -> Hash256 {
+        // FIXME(sproul): unclear if this is intended or a bug in the spec tests
+        // See: https://github.com/ethereum/consensus-specs/issues/4795
+        if self.is_empty() {
+            return mix_in_length(&Hash256::ZERO, 0);
+        }
+
         let mut hasher = ProgressiveMerkleHasher::new();
         hasher
             .write(self.as_slice())

--- a/tree_hash/src/impls.rs
+++ b/tree_hash/src/impls.rs
@@ -235,7 +235,7 @@ impl TreeHash for Bitfield<Progressive> {
         let mut hasher = ProgressiveMerkleHasher::new();
         hasher
             .write(self.as_slice())
-            .expect("ProgessiveBitList should not exceed tree hash leaf limit");
+            .expect("ProgressiveBitList should not exceed tree hash leaf limit");
 
         let bitfield_root = hasher
             .finish()

--- a/tree_hash/src/lib.rs
+++ b/tree_hash/src/lib.rs
@@ -93,6 +93,13 @@ pub fn mix_in_selector(root: &Hash256, selector: u8) -> Option<Hash256> {
     Some(Hash256::from_slice(&root))
 }
 
+pub fn mix_in_active_fields(root: Hash256, active_fields: [u8; BYTES_PER_CHUNK]) -> Hash256 {
+    Hash256::from(ethereum_hashing::hash32_concat(
+        root.as_slice(),
+        &active_fields,
+    ))
+}
+
 /// Returns a cached padding node for a given height.
 fn get_zero_hash(height: usize) -> &'static [u8] {
     if height <= ZERO_HASHES_MAX_INDEX {

--- a/tree_hash/src/lib.rs
+++ b/tree_hash/src/lib.rs
@@ -7,7 +7,9 @@ mod progressive_merkle_hasher;
 pub use merkle_hasher::{Error, MerkleHasher};
 pub use merkleize_padded::merkleize_padded;
 pub use merkleize_standard::merkleize_standard;
-pub use progressive_merkle_hasher::ProgressiveMerkleHasher;
+pub use progressive_merkle_hasher::{
+    Error as ProgressiveMerkleHasherError, ProgressiveMerkleHasher,
+};
 
 use ethereum_hashing::{hash_fixed, ZERO_HASHES, ZERO_HASHES_MAX_INDEX};
 use smallvec::SmallVec;

--- a/tree_hash/src/lib.rs
+++ b/tree_hash/src/lib.rs
@@ -2,10 +2,12 @@ pub mod impls;
 mod merkle_hasher;
 mod merkleize_padded;
 mod merkleize_standard;
+mod progressive_merkle_hasher;
 
 pub use merkle_hasher::{Error, MerkleHasher};
 pub use merkleize_padded::merkleize_padded;
 pub use merkleize_standard::merkleize_standard;
+pub use progressive_merkle_hasher::ProgressiveMerkleHasher;
 
 use ethereum_hashing::{hash_fixed, ZERO_HASHES, ZERO_HASHES_MAX_INDEX};
 use smallvec::SmallVec;

--- a/tree_hash/src/progressive_merkle_hasher.rs
+++ b/tree_hash/src/progressive_merkle_hasher.rs
@@ -1,0 +1,266 @@
+use crate::{get_zero_hash, merkle_root, Hash256, BYTES_PER_CHUNK};
+use ethereum_hashing::hash32_concat;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    /// The maximum number of leaves has been exceeded.
+    MaximumLeavesExceeded { max_leaves: usize },
+}
+
+/// A progressive Merkle hasher that implements the semantics of `merkleize_progressive` as
+/// defined in EIP-7916.
+///
+/// The progressive merkle tree has a unique structure where:
+/// - At each level, the right child is a binary merkle tree with a specific number of leaves
+/// - The left child recursively contains more progressive structure
+/// - The number of leaves in each right subtree grows by 4x at each level (1, 4, 16, 64, ...)
+///
+/// # Example Tree Structure
+///
+/// ```text
+///         root
+///          /\
+///         /  \
+///        /\   1: chunks[0 ..< 1]
+///       /  \
+///      /\   4: chunks[1 ..< 5]
+///     /  \
+///    /\  16: chunks[5 ..< 21]
+///   /  \
+///  0   64: chunks[21 ..< 85]
+/// ```
+///
+/// This structure allows efficient appending and proof generation for growing lists.
+pub struct ProgressiveMerkleHasher {
+    /// All chunks that have been written to the hasher.
+    chunks: Vec<[u8; BYTES_PER_CHUNK]>,
+    /// Maximum number of leaves this hasher can accept.
+    max_leaves: usize,
+}
+
+impl ProgressiveMerkleHasher {
+    /// Create a new progressive merkle hasher that can accept up to `max_leaves` leaves.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_leaves == 0`.
+    pub fn with_leaves(max_leaves: usize) -> Self {
+        assert!(max_leaves > 0, "must have at least one leaf");
+        Self {
+            chunks: Vec::new(),
+            max_leaves,
+        }
+    }
+
+    /// Write bytes to the hasher.
+    ///
+    /// The bytes will be split into 32-byte chunks. If the final chunk is incomplete,
+    /// it will be padded with zeros.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing these bytes would exceed the maximum number of leaves.
+    pub fn write(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        let num_new_leaves = bytes.len().div_ceil(BYTES_PER_CHUNK);
+        
+        if self.chunks.len() + num_new_leaves > self.max_leaves {
+            return Err(Error::MaximumLeavesExceeded {
+                max_leaves: self.max_leaves,
+            });
+        }
+
+        // Split bytes into 32-byte chunks
+        for chunk_bytes in bytes.chunks(BYTES_PER_CHUNK) {
+            let mut chunk = [0u8; BYTES_PER_CHUNK];
+            chunk[..chunk_bytes.len()].copy_from_slice(chunk_bytes);
+            self.chunks.push(chunk);
+        }
+
+        Ok(())
+    }
+
+    /// Finish the hasher and return the progressive merkle root.
+    ///
+    /// This implements the recursive merkleize_progressive algorithm:
+    /// - If no chunks: return zero hash
+    /// - Otherwise: hash(merkleize_progressive(left), merkleize(right))
+    ///   where right contains the first num_leaves chunks as a binary tree,
+    ///   and left recursively contains the rest with num_leaves * 4.
+    pub fn finish(self) -> Result<Hash256, Error> {
+        Ok(merkleize_progressive(&self.chunks, 1))
+    }
+}
+
+/// Recursively compute the progressive merkle root for the given chunks.
+///
+/// # Arguments
+///
+/// * `chunks` - The chunks to merkleize
+/// * `num_leaves` - The number of leaves for the right (binary tree) subtree at this level
+///
+/// # Algorithm
+///
+/// Following the spec:
+/// ```text
+/// merkleize_progressive(chunks, num_leaves=1): Given ordered BYTES_PER_CHUNK-byte chunks:
+///     The merkleization depends on the number of input chunks and is defined recursively:
+///         If len(chunks) == 0: the root is a zero value, Bytes32().
+///         Otherwise: compute the root using hash(a, b)
+///             a: Recursively merkleize chunks beyond num_leaves using 
+///                merkleize_progressive(chunks[num_leaves:], num_leaves * 4).
+///             b: Merkleize the first up to num_leaves chunks as a binary tree using 
+///                merkleize(chunks[:num_leaves], num_leaves).
+/// ```
+fn merkleize_progressive(chunks: &[[u8; BYTES_PER_CHUNK]], num_leaves: usize) -> Hash256 {
+    if chunks.is_empty() {
+        // Base case: no chunks, return zero hash
+        return Hash256::ZERO;
+    }
+
+    // Split chunks into right (first num_leaves) and left (rest)
+    let right_chunks = &chunks[..chunks.len().min(num_leaves)];
+    let left_chunks = &chunks[chunks.len().min(num_leaves)..];
+
+    // Compute right subtree: binary merkle tree with num_leaves leaves
+    let right_root = if right_chunks.is_empty() {
+        // If no chunks for right, use zero hash
+        Hash256::from_slice(get_zero_hash(compute_height(num_leaves)))
+    } else {
+        // Use merkle_root to compute binary tree root
+        let bytes: Vec<u8> = right_chunks.iter().flat_map(|c| c.iter().copied()).collect();
+        merkle_root(&bytes, num_leaves)
+    };
+
+    // Compute left subtree: recursive progressive merkle tree with num_leaves * 4
+    let left_root = merkleize_progressive(left_chunks, num_leaves * 4);
+
+    // Combine left and right roots
+    Hash256::from_slice(&hash32_concat(left_root.as_slice(), right_root.as_slice()))
+}
+
+/// Compute the height of a binary tree with the given number of leaves.
+fn compute_height(num_leaves: usize) -> usize {
+    if num_leaves == 0 {
+        0
+    } else {
+        // Height is log2(next_power_of_two(num_leaves))
+        let power_of_two = num_leaves.next_power_of_two();
+        power_of_two.trailing_zeros() as usize
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_tree() {
+        let hasher = ProgressiveMerkleHasher::with_leaves(1);
+        let root = hasher.finish().unwrap();
+        assert_eq!(root, Hash256::ZERO);
+    }
+
+    #[test]
+    fn test_single_chunk() {
+        let mut hasher = ProgressiveMerkleHasher::with_leaves(1);
+        let chunk = [1u8; BYTES_PER_CHUNK];
+        hasher.write(&chunk).unwrap();
+        let root = hasher.finish().unwrap();
+        
+        // For a single chunk, the progressive tree should be:
+        // hash(merkleize_progressive([], 4), merkleize([chunk], 1))
+        // = hash(zero_hash, chunk)
+        let zero_left = Hash256::ZERO;
+        let right = Hash256::from_slice(&chunk);
+        let expected = Hash256::from_slice(&hash32_concat(
+            zero_left.as_slice(),
+            right.as_slice()
+        ));
+        
+        assert_eq!(root, expected);
+    }
+
+    #[test]
+    fn test_two_chunks() {
+        let mut hasher = ProgressiveMerkleHasher::with_leaves(5);
+        let chunk1 = [1u8; BYTES_PER_CHUNK];
+        let chunk2 = [2u8; BYTES_PER_CHUNK];
+        hasher.write(&chunk1).unwrap();
+        hasher.write(&chunk2).unwrap();
+        let root = hasher.finish().unwrap();
+        
+        // First chunk goes to right (num_leaves=1)
+        // Second chunk goes to left recursive call (num_leaves=4)
+        
+        // Right: binary tree with 1 leaf = chunk1
+        let right = Hash256::from_slice(&chunk1);
+        
+        // Left: progressive tree with chunk2 at num_leaves=4
+        // At this level: hash(merkleize_progressive([], 16), merkleize([chunk2], 4))
+        // = hash(zero_hash, merkle([chunk2], 4))
+        let chunk2_padded = merkle_root(&chunk2, 4);
+        let zero_left_inner = Hash256::ZERO;
+        let left = Hash256::from_slice(&hash32_concat(
+            zero_left_inner.as_slice(),
+            chunk2_padded.as_slice()
+        ));
+        
+        let expected = Hash256::from_slice(&hash32_concat(left.as_slice(), right.as_slice()));
+        assert_eq!(root, expected);
+    }
+
+    #[test]
+    fn test_max_leaves_exceeded() {
+        let mut hasher = ProgressiveMerkleHasher::with_leaves(2);
+        let chunk = [1u8; BYTES_PER_CHUNK];
+        hasher.write(&chunk).unwrap();
+        hasher.write(&chunk).unwrap();
+        
+        // Third write should fail
+        let result = hasher.write(&chunk);
+        assert!(matches!(result, Err(Error::MaximumLeavesExceeded { .. })));
+    }
+
+    #[test]
+    fn test_partial_chunk() {
+        let mut hasher = ProgressiveMerkleHasher::with_leaves(1);
+        let partial = vec![1u8, 2u8, 3u8];
+        hasher.write(&partial).unwrap();
+        let root = hasher.finish().unwrap();
+        
+        // Partial chunk should be padded with zeros
+        let mut chunk = [0u8; BYTES_PER_CHUNK];
+        chunk[0] = 1;
+        chunk[1] = 2;
+        chunk[2] = 3;
+        
+        let zero_left = Hash256::ZERO;
+        let right = Hash256::from_slice(&chunk);
+        let expected = Hash256::from_slice(&hash32_concat(
+            zero_left.as_slice(),
+            right.as_slice()
+        ));
+        
+        assert_eq!(root, expected);
+    }
+
+    #[test]
+    fn test_multiple_writes() {
+        let mut hasher = ProgressiveMerkleHasher::with_leaves(10);
+        hasher.write(&[1u8; 16]).unwrap();
+        hasher.write(&[2u8; 16]).unwrap();
+        hasher.write(&[3u8; 32]).unwrap();
+        let root = hasher.finish().unwrap();
+        
+        // Should handle multiple writes correctly
+        assert_ne!(root, Hash256::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "must have at least one leaf")]
+    fn test_zero_leaves_panics() {
+        ProgressiveMerkleHasher::with_leaves(0);
+    }
+}

--- a/tree_hash/src/progressive_merkle_hasher.rs
+++ b/tree_hash/src/progressive_merkle_hasher.rs
@@ -183,8 +183,7 @@ impl ProgressiveMerkleHasher {
         // - result accumulates the left subtree (deeper/larger levels)
         // - completed_root is the right subtree at this level
         for &completed_root in completed_roots.iter().rev() {
-            result =
-                Hash256::from_slice(&hash32_concat(result.as_slice(), completed_root.as_slice()));
+            result = Hash256::from(hash32_concat(result.as_slice(), completed_root.as_slice()));
         }
 
         result

--- a/tree_hash/src/progressive_merkle_hasher.rs
+++ b/tree_hash/src/progressive_merkle_hasher.rs
@@ -190,6 +190,12 @@ impl ProgressiveMerkleHasher {
     }
 }
 
+impl Default for ProgressiveMerkleHasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tree_hash/src/progressive_merkle_hasher.rs
+++ b/tree_hash/src/progressive_merkle_hasher.rs
@@ -154,7 +154,8 @@ fn merkleize_progressive(chunks: &[[u8; BYTES_PER_CHUNK]], num_leaves: usize) ->
     // Compute left subtree: recursive progressive merkle tree with num_leaves * 4
     let left_root = merkleize_progressive(left_chunks, num_leaves * 4);
 
-    // Combine left and right roots
+    // Combine left and right roots according to spec: hash(a, b) where
+    // a = left subtree (recursive progressive), b = right subtree (binary tree)
     Hash256::from_slice(&hash32_concat(left_root.as_slice(), right_root.as_slice()))
 }
 

--- a/tree_hash/tests/tests.rs
+++ b/tree_hash/tests/tests.rs
@@ -1,5 +1,6 @@
 use alloy_primitives::{Address, U128, U160, U256};
 use ssz_derive::Encode;
+use std::str::FromStr;
 use tree_hash::{Hash256, MerkleHasher, PackedEncoding, TreeHash, BYTES_PER_CHUNK};
 use tree_hash_derive::TreeHash;
 
@@ -166,4 +167,20 @@ fn packed_encoding_example() {
             "encoding {i} is wrong"
         );
     }
+}
+
+#[derive(TreeHash)]
+#[tree_hash(struct_behaviour = "progressive_container", active_fields(1))]
+struct ProgressiveContainerOneField {
+    x: u8,
+}
+
+#[test]
+fn progressive_container_one_field() {
+    let container = ProgressiveContainerOneField { x: 125 };
+    assert_eq!(
+        container.tree_hash_root(),
+        Hash256::from_str("0xfacc8073916cbe1d3e400f69945fb5b6423d1e8f99be04713bcbe254fad2c94c")
+            .unwrap()
+    );
 }

--- a/tree_hash/tests/tests.rs
+++ b/tree_hash/tests/tests.rs
@@ -180,7 +180,7 @@ fn progressive_container_one_field() {
     let container = ProgressiveContainerOneField { x: 125 };
     assert_eq!(
         container.tree_hash_root(),
-        Hash256::from_str("0xfacc8073916cbe1d3e400f69945fb5b6423d1e8f99be04713bcbe254fad2c94c")
+        Hash256::from_str("0xb6a2f148c33179dec1bdaa979a11776ff2d881fca93974b286443a8539dc0872")
             .unwrap()
     );
 }

--- a/tree_hash_derive/src/attrs.rs
+++ b/tree_hash_derive/src/attrs.rs
@@ -16,7 +16,11 @@ pub struct StructOpts {
 }
 
 /// Variant-level configuration (for enums).
-#[derive(Debug, Default, FromMeta)]
+///
+/// These attributes NEED to be kept in sync with `ethereum_ssz` because both crates try to read
+/// each others attributes to avoid mandatory duplication. In future this might mean parsing some
+/// SSZ-only attributes here and then ignoring them.
+#[derive(Debug, Default, PartialEq, FromMeta)]
 pub struct VariantOpts {
     #[darling(default)]
     pub selector: Option<u8>,

--- a/tree_hash_derive/src/attrs.rs
+++ b/tree_hash_derive/src/attrs.rs
@@ -1,0 +1,127 @@
+use darling::{ast::NestedMeta, Error, FromDeriveInput, FromMeta};
+use quote::quote;
+
+pub const MAX_ACTIVE_FIELDS: usize = 256;
+pub const ACTIVE_FIELDS_PACKED_BITS_LEN: usize = MAX_ACTIVE_FIELDS / 8;
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(tree_hash))]
+pub struct StructOpts {
+    #[darling(default)]
+    pub enum_behaviour: Option<EnumBehaviour>,
+    #[darling(default)]
+    pub struct_behaviour: Option<StructBehaviour>,
+    #[darling(default)]
+    pub active_fields: Option<ActiveFields>,
+}
+
+#[derive(Debug, FromMeta)]
+pub enum EnumBehaviour {
+    Transparent,
+    Union,
+}
+
+#[derive(Debug, Default, FromMeta)]
+pub enum StructBehaviour {
+    #[default]
+    Container,
+    ProgressiveContainer,
+}
+
+#[derive(Debug)]
+pub struct ActiveFields {
+    pub active_fields: Vec<bool>,
+}
+
+impl FromMeta for ActiveFields {
+    fn from_list(items: &[NestedMeta]) -> Result<Self, Error> {
+        let active_fields = items
+            .iter()
+            .map(|nested_meta| match u8::from_nested_meta(nested_meta) {
+                Ok(0) => Ok(false),
+                Ok(1) => Ok(true),
+                Ok(n) => Err(Error::custom(format!(
+                    "invalid integer in active_fields: {n}"
+                ))),
+                Err(e) => Err(Error::custom(format!(
+                    "unable to parse active_fields entry: {e:?}"
+                ))),
+            })
+            .collect::<Result<_, _>>()?;
+        Self::new(active_fields)
+    }
+}
+
+impl ActiveFields {
+    fn new(active_fields: Vec<bool>) -> Result<Self, Error> {
+        if active_fields.is_empty() {
+            return Err(Error::custom(format!("active_fields must be non-empty")));
+        }
+        if active_fields.len() > MAX_ACTIVE_FIELDS {
+            return Err(Error::custom(format!(
+                "active_fields cannot contain more than {MAX_ACTIVE_FIELDS} entries"
+            )));
+        }
+
+        if let Some(false) = active_fields.last() {
+            return Err(Error::custom(format!(
+                "the last entry of active_fields must not be 0"
+            )));
+        }
+
+        Ok(Self { active_fields })
+    }
+
+    pub fn packed(&self) -> [u8; ACTIVE_FIELDS_PACKED_BITS_LEN] {
+        let mut result = [0; ACTIVE_FIELDS_PACKED_BITS_LEN];
+        for (i, bit) in self.active_fields.iter().enumerate() {
+            if *bit {
+                result[i / 8] |= 1 << (i % 8);
+            }
+        }
+        result
+    }
+
+    /// Return tokens for the packed representation of these `active_fields`.
+    ///
+    /// We compute the packed representation at compile-time, and then inline it via the output
+    /// of this function.
+    pub fn packed_tokens(&self) -> proc_macro2::TokenStream {
+        let packed = self.packed().to_vec();
+        quote! {
+            [
+                #(#packed),*
+            ]
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn active_fields_packed_basic() {
+        let active_fields = ActiveFields {
+            active_fields: vec![true],
+        };
+        assert_eq!(
+            active_fields.packed(),
+            [
+                0b0000001, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0,
+            ]
+        );
+
+        let active_fields = ActiveFields {
+            active_fields: vec![true, false, true, false, false, true],
+        };
+        assert_eq!(
+            active_fields.packed(),
+            [
+                0b0100101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0,
+            ]
+        );
+    }
+}

--- a/tree_hash_derive/src/attrs.rs
+++ b/tree_hash_derive/src/attrs.rs
@@ -67,7 +67,7 @@ impl FromMeta for ActiveFields {
 impl ActiveFields {
     fn new(active_fields: Vec<bool>) -> Result<Self, Error> {
         if active_fields.is_empty() {
-            return Err(Error::custom(format!("active_fields must be non-empty")));
+            return Err(Error::custom("active_fields must be non-empty".to_string()));
         }
         if active_fields.len() > MAX_ACTIVE_FIELDS {
             return Err(Error::custom(format!(
@@ -76,9 +76,9 @@ impl ActiveFields {
         }
 
         if let Some(false) = active_fields.last() {
-            return Err(Error::custom(format!(
-                "the last entry of active_fields must not be 0"
-            )));
+            return Err(Error::custom(
+                "the last entry of active_fields must not be 0".to_string(),
+            ));
         }
 
         Ok(Self { active_fields })

--- a/tree_hash_derive/src/attrs.rs
+++ b/tree_hash_derive/src/attrs.rs
@@ -15,10 +15,18 @@ pub struct StructOpts {
     pub active_fields: Option<ActiveFields>,
 }
 
+/// Variant-level configuration (for enums).
+#[derive(Debug, Default, FromMeta)]
+pub struct VariantOpts {
+    #[darling(default)]
+    pub selector: Option<u8>,
+}
+
 #[derive(Debug, FromMeta)]
 pub enum EnumBehaviour {
     Transparent,
     Union,
+    CompatibleUnion,
 }
 
 #[derive(Debug, Default, FromMeta)]

--- a/tree_hash_derive/src/lib.rs
+++ b/tree_hash_derive/src/lib.rs
@@ -154,7 +154,10 @@ fn tree_hash_derive_struct(
     let output = quote! {
         impl #impl_generics tree_hash::TreeHash for #name #ty_generics #where_clause {
             fn tree_hash_type() -> tree_hash::TreeHashType {
-                // FIXME(sproul): consider adjusting this with active_fields
+                // There is no specific type for progressive containers, although we could consider
+                // adding one in future if it would prove useful.
+                //
+                // See: https://github.com/sigp/tree_hash/issues/44
                 tree_hash::TreeHashType::Container
             }
 


### PR DESCRIPTION
This PR contains all of the `tree_hash` changes required to support [EIP-7916](https://eips.ethereum.org/EIPS/eip-7916) and [EIP-8016](https://eips.ethereum.org/EIPS/eip-8016):

- `ProgressiveMerkleHasher`: an analog of `MerkleHasher`, it has a lazy API where it can ingest bytes and hash them incrementally. It uses a `MerkleHasher` under the hood to do the hashing of the binary subtrees.
- `TreeHash` implementation for `Bitfield<Progressive>` from `ethereum_ssz`.
- Derive macro support for `struct_behaviour = "progressive_container"`. This generates code that uses a `ProgressiveMerkleHasher` for the fields. It comes with a new attribute `active_fields({0,1},+)` which is used to insert zero hashes for inactivated fields. The derive macro also generates a 32-byte array representing the active fields as a bitfield (at compile time), and generates code to mix this bitfield into the root, following the spec.
- Derive macro support for `enum_behaviour = "compatible_union"`. Compatible unions behave quite similarly to the existing (and now deprecated) union type, with the difference being that their g-indices and merkle tree structure is stable across all enum variants. For now the macro **does not verify** that enum variants are compatible, because this verification is not mandatory (it is safe if the only compatible unions happen to be compatible, which the spec should ensure). Verification is left for a follow-up PR: https://github.com/sigp/ethereum_ssz/issues/72.
- As part of compatible union support, we add a new variant attribute `tree_hash(selector = "1")` which can set the selector **for compatible unions only**. To avoid duplication with `ethereum_ssz` this selector is read from the `ssz` attribute, _or_ the `tree_hash` attribute (they must be consistent if both are set). See discussion: https://github.com/sigp/lighthouse/pull/8505#discussion_r2681151836.

Depends on:

- https://github.com/sigp/ethereum_ssz/pull/67